### PR TITLE
Fixed wrong class naming convention

### DIFF
--- a/AutoItCSharpWrapper/AutoItCSharpWrapper/Program.cs
+++ b/AutoItCSharpWrapper/AutoItCSharpWrapper/Program.cs
@@ -8,13 +8,13 @@ using AutoItX3Lib;
 
 namespace AutoItCSharpWrapper
 {
-    public class AU3
+    public class Au3
     {
         public static AutoItX3Lib.AutoItX3 au3;
 
         private static string _lastWindow = "";
 
-        static AU3()
+        static Au3()
         {
             au3 = new AutoItX3Lib.AutoItX3();
         }
@@ -449,7 +449,7 @@ namespace AutoItCSharpWrapper
             Thread.Sleep( ms );
         }
     }
-    class Program : AU3
+    class Program : Au3
     {
         static void Main( string[] args )
         {


### PR DESCRIPTION
Class and method names in C# should be pascal-case.

I guess if it was called AI3 then maybe it would make sense given A and I represent two different words. But u is inside AutoIt, so it should be lower-case in this instance.
